### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+theme/* linguist-vendored
+widget/* linguist-vendored


### PR DESCRIPTION
Hi Menno,

By adding this file, Github linguist excludes the theme and widget foledrs so the programming lanuage is correctly detected. See https://github.com/github/linguist. Also applicable to other repositories.